### PR TITLE
Added trailer support for serverstream and duplex calls

### DIFF
--- a/__tests__/callFactories/generateDuplexCall.js
+++ b/__tests__/callFactories/generateDuplexCall.js
@@ -14,25 +14,25 @@ describe("Unit test for generating Duplex Call", () => {
   });
 
   describe("Duplex should have methods", () => {
-    xtest("Duplex Call must have throw method", () => {
+    test("Duplex Call must have throw method", () => {
       expect(typeof mockDuplex.throw === "function").toBe(true);
     });
 
-    xtest("Duplex Call must have sendMeta method", () => {
+    test("Duplex Call must have sendMeta method", () => {
       expect(typeof mockDuplex.sendMeta === "function").toBe(true);
     });
 
-    xtest("Duplex Call must have on method", () => {
+    test("Duplex Call must have on method", () => {
       expect(typeof mockDuplex.on === "function").toBe(true);
     });
 
-    xtest("Duplex Call must have write method", () => {
+    test("Duplex Call must have write method", () => {
       expect(typeof mockDuplex.write === "function").toBe(true);
     });
   });
 
   describe("Duplex has setStatus and sends trailers with errors.", () => {
-    xit(".setStatus modifies the trailerObject Property", () => {
+    it(".setStatus modifies the trailerObject Property", () => {
       const mockDuplex = generateDuplexCall(mockDuplexStream);
       mockDuplex.setStatus({ test: "test" });
       expect(mockDuplex.trailerObject).toEqual({ test: "test" });

--- a/__tests__/callFactories/generateDuplexCall.js
+++ b/__tests__/callFactories/generateDuplexCall.js
@@ -1,28 +1,54 @@
-const generateDuplexCall = require('../../lib/callFactories/generateDuplex')
+const generateDuplexCall = require("../../lib/callFactories/generateDuplex");
+
+const mockEmit = jest.fn();
 const mockDuplexStream = {
   on: () => {},
   write: () => {},
+  emit: mockEmit
 };
 const mockDuplex = generateDuplexCall(mockDuplexStream);
 
-describe('Unit test for generating Duplex Call', () => {
-  
-  describe('Duplex should have methods', () => {
+describe("Unit test for generating Duplex Call", () => {
+  beforeAll(() => {
+    mockEmit.mockClear();
+  });
 
-    test('Duplex Call must have throw method', () => {
-      expect(typeof mockDuplex.throw === 'function').toBe(true);
-    })
+  describe("Duplex should have methods", () => {
+    xtest("Duplex Call must have throw method", () => {
+      expect(typeof mockDuplex.throw === "function").toBe(true);
+    });
 
-    test('Duplex Call must have sendMeta method', () => {
-      expect(typeof mockDuplex.sendMeta === 'function').toBe(true);
-    })
+    xtest("Duplex Call must have sendMeta method", () => {
+      expect(typeof mockDuplex.sendMeta === "function").toBe(true);
+    });
 
-    test('Duplex Call must have on method', () => {
-      expect(typeof mockDuplex.on === 'function').toBe(true);
-    })
+    xtest("Duplex Call must have on method", () => {
+      expect(typeof mockDuplex.on === "function").toBe(true);
+    });
 
-    test('Duplex Call must have write method', () => {
-      expect(typeof mockDuplex.write === 'function').toBe(true);
-    })
-  })
-})
+    xtest("Duplex Call must have write method", () => {
+      expect(typeof mockDuplex.write === "function").toBe(true);
+    });
+  });
+
+  describe("Duplex has setStatus and sends trailers with errors.", () => {
+    xit(".setStatus modifies the trailerObject Property", () => {
+      const mockDuplex = generateDuplexCall(mockDuplexStream);
+      mockDuplex.setStatus({ test: "test" });
+      expect(mockDuplex.trailerObject).toEqual({ test: "test" });
+    });
+
+    it("Emit error now sends grpc.Metadata Object with error property.", () => {
+      const mockDuplex = generateDuplexCall(mockDuplexStream);
+      mockDuplex.setStatus({ test: "test" });
+      mockDuplex.throw(new Error("error"));
+      expect(mockEmit.mock.calls[0][1].constructor.name).toBe("Error");
+      expect(
+        mockEmit.mock.calls[0][1].metadata.hasOwnProperty("_internal_repr")
+      ).toBeTruthy();
+      expect(mockEmit.mock.calls[0][1].metadata._internal_repr).toEqual({
+        test: ["test"]
+      });
+    });
+  });
+});

--- a/__tests__/callFactories/generateServerStreamCall.js
+++ b/__tests__/callFactories/generateServerStreamCall.js
@@ -1,39 +1,66 @@
-const generateServerStreamCall = require('../../lib/callFactories/generateServerStreamCall')
-const mockServerReadableStream = {write: () => {}};
-const mockServerWritable = generateServerStreamCall(mockServerReadableStream);
+const generateServerStreamCall = require("../../lib/callFactories/generateServerStreamCall");
+const mockEmit = jest.fn();
+const mockServerWritableStream = { write: () => {}, emit: mockEmit };
+const mockServerWritable = generateServerStreamCall(mockServerWritableStream);
 
-describe('Unit tests for generating Server Stream Call', () => {
-  describe('Server Stream should have properties', () => {
+describe("Unit tests for generating Server Stream Call", () => {
+  describe("Server Stream should have properties", () => {
+    test("Server Stream Call must have metaData property", () => {
+      expect(mockServerWritable.hasOwnProperty("metaData")).toBe(true);
+    });
 
-    test('Server Stream Call must have metaData property', () => {
-      expect(mockServerWritable.hasOwnProperty('metaData')).toBe(true);
-    })
+    test("Server Stream Call must have req property", () => {
+      expect(mockServerWritable.hasOwnProperty("req")).toBe(true);
+    });
 
-    test('Server Stream Call must have req property', () => {
-      expect(mockServerWritable.hasOwnProperty('req')).toBe(true);
-    })
+    test("Server Stream Call req must have meta property", () => {
+      expect(mockServerWritable.req.hasOwnProperty("meta")).toBe(true);
+    });
 
-    test('Server Stream Call req must have meta property', () => {
-      expect(mockServerWritable.req.hasOwnProperty('meta')).toBe(true);
-    })
-
-    test('Server Stream Call req must have data property', () => {
-      expect(mockServerWritable.req.hasOwnProperty('data')).toBe(true);
-    })
+    test("Server Stream Call req must have data property", () => {
+      expect(mockServerWritable.req.hasOwnProperty("data")).toBe(true);
+    });
   });
 
-  describe('Server Stream should have methods', () => {
+  describe("Server Stream should have methods", () => {
+    test("Server Stream Call must have throw method", () => {
+      expect(typeof mockServerWritable.throw === "function").toBe(true);
+    });
 
-    test('Server Stream Call must have throw method', () => {
-      expect(typeof mockServerWritable.throw === 'function').toBe(true);
-    })
+    test("Server Stream Call must have setMeta method", () => {
+      expect(typeof mockServerWritable.sendMeta === "function").toBe(true);
+    });
 
-    test('Server Stream Call must have setMeta method', () => {
-      expect(typeof mockServerWritable.sendMeta === 'function').toBe(true);
-    })
+    test("Server Stream Call must have write method", () => {
+      expect(typeof mockServerWritable.write === "function").toBe(true);
+    });
+  });
 
-    test('Server Stream Call must have write method', () => {
-      expect(typeof mockServerWritable.write === 'function').toBe(true);
-    })
-  })
-})
+  describe("ServerStreamCloe has setStatus and sends trailers with errors.", () => {
+    beforeAll(() => {
+      mockEmit.mockClear();
+    });
+    it(".setStatus modifies the trailerObject Property", () => {
+      const mockServerWritable = generateServerStreamCall(
+        mockServerWritableStream
+      );
+      mockServerWritable.setStatus({ test: "test" });
+      expect(mockServerWritable.trailerObject).toEqual({ test: "test" });
+    });
+
+    it("Emit error now sends grpc.Metadata Object with error property.", () => {
+      const mockServerWritable = generateServerStreamCall(
+        mockServerWritableStream
+      );
+      mockServerWritable.setStatus({ test: "test" });
+      mockServerWritable.throw(new Error("error"));
+      expect(mockEmit.mock.calls[0][1].constructor.name).toBe("Error");
+      expect(
+        mockEmit.mock.calls[0][1].metadata.hasOwnProperty("_internal_repr")
+      ).toBeTruthy();
+      expect(mockEmit.mock.calls[0][1].metadata._internal_repr).toEqual({
+        test: ["test"]
+      });
+    });
+  });
+});

--- a/examples/vanilla_gRPC/methodHandlers.js
+++ b/examples/vanilla_gRPC/methodHandlers.js
@@ -2,10 +2,14 @@ const grpc = require("grpc");
 
 function unaryChat(call, callback) {
   const meta = new grpc.Metadata();
+  meta.set("trailertest", "trailers");
+  // console.log({ meta });
   const { request } = call;
   console.log(request);
   const response = { message: request.message + " World" };
-  callback(null, response, meta);
+  let err = new Error("hello");
+  err.metadata = meta;
+  callback(err, response, meta);
 }
 
 function serverStream(call) {

--- a/lib/callFactories/generateDuplex.js
+++ b/lib/callFactories/generateDuplex.js
@@ -6,7 +6,7 @@ const generateMeta = require("../utils/generateMeta");
 
 function generateDuplex(ServerDuplexStream) {
   const ServerDuplexStreamClone = Object.create(ServerDuplexStream);
-  ServerWritableStreamClone.trailerObject = undefined;
+  ServerDuplexStreamClone.trailerObject = undefined;
   ServerDuplexStreamClone.throw = function(err) {
     if (!(err instanceof Error)) {
       throw new Error(
@@ -16,7 +16,7 @@ function generateDuplex(ServerDuplexStream) {
     err.metadata = generateMeta(this.trailerObject);
     this.emit("error", err);
   };
-  ServerWritableStreamClone.setStatus = function(trailerObject) {
+  ServerDuplexStreamClone.setStatus = function(trailerObject) {
     this.trailerObject = trailerObject;
   };
   ServerDuplexStreamClone.sendMeta = function(metaObject) {

--- a/lib/callFactories/generateDuplex.js
+++ b/lib/callFactories/generateDuplex.js
@@ -1,16 +1,23 @@
 const grpc = require("grpc");
 
+const generateMeta = require("../utils/generateMeta");
+
 // function will take in a duplex call constructor, and return a class which extends the class with our own built in methods on top
 
 function generateDuplex(ServerDuplexStream) {
   const ServerDuplexStreamClone = Object.create(ServerDuplexStream);
+  ServerWritableStreamClone.trailerObject = undefined;
   ServerDuplexStreamClone.throw = function(err) {
     if (!(err instanceof Error)) {
       throw new Error(
         "Please pass your error details as an Error class. Firecomm supports adding additional error metadata in the trailers property using context.setStatus()"
       );
     }
+    err.metadata = generateMeta(this.trailerObject);
     this.emit("error", err);
+  };
+  ServerWritableStreamClone.setStatus = function(trailerObject) {
+    this.trailerObject = trailerObject;
   };
   ServerDuplexStreamClone.sendMeta = function(metaObject) {
     const metaData = new grpc.Metadata();

--- a/lib/callFactories/generateServerStreamCall.js
+++ b/lib/callFactories/generateServerStreamCall.js
@@ -1,8 +1,11 @@
 const grpc = require("grpc");
 
+const generateMeta = require("../utils/generateMeta");
+
 function generateServerStreamCall(ServerWritableStream) {
   ServerWritableStreamClone = Object.create(ServerWritableStream);
   ServerWritableStreamClone.metaData = undefined;
+  ServerWritableStreamClone.trailerObject = undefined;
   ServerWritableStreamClone.req = { meta: this.metadata, data: this.request };
   ServerWritableStreamClone.throw = function(err) {
     if (!(err instanceof Error)) {
@@ -10,7 +13,11 @@ function generateServerStreamCall(ServerWritableStream) {
         "Please pass your error details as an Error class. Firecomm supports adding additional error metadata in the trailers property using context.setStatus()"
       );
     }
+    err.metadata = generateMeta(this.trailerObject);
     this.emit("error", err);
+  };
+  ServerWritableStreamClone.setStatus = function(trailerObject) {
+    this.trailerObject = trailerObject;
   };
   ServerWritableStreamClone.sendMeta = function(metaObject) {
     const metaData = new grpc.Metadata();


### PR DESCRIPTION
1) setStatus method on calls now adds trailer object
2) trailer object gets sent as grpc.Metadata stored on emitted error
3) added tests for serverstreamCall
4) added tests for duplexCall